### PR TITLE
Added support for Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - pip3 install -e .[dev]
   - pip3 install coveralls

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,14 @@ setup(
     url=pypackagery_meta.__url__,
     author=pypackagery_meta.__author__,
     author_email=pypackagery_meta.__author_email__,
+    # yapf: disable
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Development Status :: 5 - Production/Stable', 'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License', 'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6', 'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ],
+    # yapf: enable
     license='License :: OSI Approved :: MIT License',
     keywords='package monorepo requirements',
     packages=find_packages(exclude=['tests']),


### PR DESCRIPTION
We support Python 3.7 and 3.8 by including them in the continuous
integration.